### PR TITLE
Make CJK(Chinese,Japanese,Korean) characters safe

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -24,7 +24,7 @@ def log(message):
             lf.write(f'{message}\n')
 
 def safe_str(name):
-    return  re.sub(r'[^.a-zA-Z0-9א-ת]', '_', name)
+    return  re.sub(r'[^.a-zA-Z0-9一-鿆ぁ-んァ-ヾㄱ-힝々א-ת]', '_', name)
 
 def should_handle(path):
     return path.startswith(LIMIT_EXPORT)


### PR DESCRIPTION
These CJK(Chinese,Japanese,Korean) characters `[一-鿆]` `[ぁ-ん]` `[ァ-ヾ]` `[ㄱ-힝]` `々` are commonly used and should not be replaced into `_`. 

I tried adding the regex before  `א-ת` but caused a bug related to `RIGHT-TO-LEFT`. Adding it after that is OK.